### PR TITLE
Disable the binary protocol

### DIFF
--- a/subscribe.js
+++ b/subscribe.js
@@ -20,6 +20,7 @@ var subscribe = function(subID) {
       key: config.key,
       environment: config.environment,
       useTokenAuth: true,
+      useBinaryProtocol: false,
       // defaults to 1. Can increase for debugging purposes
       log: { level: 1 }
     });


### PR DESCRIPTION
The binary protocol (i.e. msgpack), while much more space-efficient for large binary payloads, is a little slower, so for your usage pattern (small messages with large fanout) we've found it's more efficient to disable it.

Also, browsers have the binary protocol disabled by default, so this makes the test more similar to the browser environment.